### PR TITLE
Revert sd from mosaic back to base

### DIFF
--- a/R/sd.R
+++ b/R/sd.R
@@ -1,0 +1,4 @@
+sd <- function(...) {
+  value <- stats::sd(...)
+  return(value)
+}


### PR DESCRIPTION
This should solve the weird histogram bug where fitted "Gaussian" curves were spitting back errors.